### PR TITLE
Bug: Missing function `_force_rehash()` results in error `command not found: _force_rehash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ### Usage
 
-For bash users, source `shell/pinyin-comp.bash` in your `~/.bashrc`
+For Bash users, source `shell/pinyin-comp.bash` in your `~/.bashrc`
 
-For zsh users, source `shell/pinyin.comp.zsh` in your `~/.zshrc`
+For Zsh users, source `shell/pinyin-comp.zsh` in your `~/.zshrc`
 
 ### Others
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(  name="pinyin-comp",
         description="complete path containing Chinese by pinyin acronym",
         author="Jekyll Wu",
         author_email="adaptee@gmail.com",
-        url="http://www.github.com/adaptee/pinyin-comp",
+        url="http://github.com/adaptee/pinyin-completion",
         packages=['pinyin'],
         scripts=['pinyin-comp'] ,
      )

--- a/shell/pinyin-comp.zsh
+++ b/shell/pinyin-comp.zsh
@@ -9,6 +9,13 @@ function _pinyin_comp()
     reply=($(pinyin-comp 0 $*))
 }
 
+# force rehash when command not found
+# Refer to http://zshwiki.org/home/examples/compsys/general
+_force_rehash() {
+    (( CURRENT == 1 )) && rehash
+    return 1 # Because we did not really complete anything
+}
+
 # pinyin-comp is performed as one part of user-expand
 zstyle ':completion:*' user-expand _pinyin_comp
 

--- a/shell/pinyin-comp.zsh
+++ b/shell/pinyin-comp.zsh
@@ -23,6 +23,7 @@ zstyle ':completion:*' user-expand _pinyin_comp
 zstyle ':completion:*:user-expand:*' tag-order '!original'
 
 # make use-expand perform as last, when needed
-zstyle ':completion:*' completer _oldlist _expand _force_rehash _complete _match _user_expand
+zstyle ':completion:*' completer \
+    _oldlist _expand _force_rehash _complete _match _user_expand
 
-# vim:set ft=zsh :
+# vim:set ft=zsh et:


### PR DESCRIPTION
@petronny ，您好！

首先感谢您接手此项目并将此软件带到 [archlinuxcn] 仓库。 :rose: 

在此我冒昧报告数个问题：

1、 安装此软件并按照说明进行相应配置后，首次打开终端使用时不断输出以下错误：

```sh
_main_complete:178: command not found: _force_rehash
```

我并未在 [Zsh](https://www.archlinux.org/packages/extra/x86_64/zsh/) 软件包内发现 `_force_rehash` 命令。通过 Google 搜索发现此函数的定义出现在以下网页 [examples:compsys:general [ZshWiki]](http://zshwiki.org/home/examples/compsys/general)。将此网页中提到的函数定义加入到 [pinyin-comp.zsh](https://github.com/petronny/pinyin-completion/blob/master/shell/pinyin-comp.zsh) 后，错误提示消失，软件运行正常。

请求大神修复此错误！在此附上本人的参考解决方案。

2、 普通的 `Zsh` 补全有着色，而中文补全无着色，应该怎样使中文补全有着色？见图：

![cd1](https://cloud.githubusercontent.com/assets/2487841/5753160/47c39c98-9cbf-11e4-973d-f398b2218490.png)

![cd2](https://cloud.githubusercontent.com/assets/2487841/5753104/044a66e6-9cbe-11e4-8304-63912a1ace75.png)

3、 当出现多于一个匹配的中文目录补全时，按 `Tab` 键不知为何会增加一项候选，内容为所有匹配中文目录连接在一起的字符串（并不存在名字为此字符串的目录），见图：

![cd3](https://cloud.githubusercontent.com/assets/2487841/5753313/f622c6f4-9cc1-11e4-9cf9-078d5f72ac1f.png)

如何去掉这一项多余且不存在的候选？

顺便一提，既然原作者已经放弃此项目，而且 [archlinuxcn] 仓库中的软件包使用本仓库作为源，希望大神能够开启本仓库 `Issues` 页面，以方便大家在此提出本项目相关的问题。

在此祝您新年愉快！

此致！