### PR TITLE
Bug: 在 `if` 语句中定义 `_force_rehash` 函数无效

### DIFF
--- a/shell/pinyin-comp.zsh
+++ b/shell/pinyin-comp.zsh
@@ -13,7 +13,7 @@ function _pinyin_comp()
 # Refer to http://zshwiki.org/home/examples/compsys/general
 #
 #
-_force_rehash() {
+_pinyin_force_rehash() {
     (( CURRENT == 1 )) && rehash
     return 1 # Because we did not really complete anything
 }
@@ -26,6 +26,6 @@ zstyle ':completion:*:user-expand:*' tag-order expansions
 
 # make use-expand perform as last, when needed
 zstyle ':completion:*' completer \
-    _oldlist _expand _force_rehash _complete _match _user_expand
+    _oldlist _expand _pinyin_force_rehash _complete _match _user_expand
 
 # vim:set ft=zsh et:

--- a/shell/pinyin-comp.zsh
+++ b/shell/pinyin-comp.zsh
@@ -13,13 +13,10 @@ function _pinyin_comp()
 # Refer to http://zshwiki.org/home/examples/compsys/general
 #
 #
-if [[ -n `whence -f _force_rehash` ]]
-then
-        _force_rehash() {
-                (( CURRENT == 1 )) && rehash
-                return 1 # Because we did not really complete anything
-        }
-fi
+_force_rehash() {
+    (( CURRENT == 1 )) && rehash
+    return 1 # Because we did not really complete anything
+}
 
 # pinyin-comp is performed as one part of user-expand
 zstyle ':completion:*' user-expand _pinyin_comp


### PR DESCRIPTION
@petronny ，您好！

您在提交 https://github.com/petronny/pinyin-completion/commit/48b6f2be612208973729898145053919302c10c4 中作出的更改依然未能解决问题。我没有学习过 `Zsh` 的语法，但是我发现在 `if` 语句中定义 `_force_rehash` 函数是无效的， Issue #1 中出现的错误又再次出现。我看了一下 `grml-zsh-config` 中的[同名函数](http://git.grml.org/?p=grml-etc-core.git;f=etc/zsh/zshrc;hb=HEAD#l731)，它们应该是一模一样的，所以再次定义应该不会导致什么问题。即使为了安全起见，也建议采用将函数 `_force_rehash` 重命名的办法。在此附上本人的参考解决方案。

在此祝您新年愉快！ :gift: 

此致！ :bow: 