### PR TITLE
Fix shebang of pinyin-comp

### DIFF
--- a/pinyin-comp
+++ b/pinyin-comp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding:utf-8 -*-
 """
 complete path by acronym of pinyin initials


### PR DESCRIPTION
NixOS doesn't have /usr/bin/python